### PR TITLE
Return jwt from user registration

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -28,7 +28,8 @@
     ],
     "require": {
         "adhocore/jwt": "^1.1",
-        "monolog/monolog": "^2.2"
+        "monolog/monolog": "^2.2",
+        "firebase/php-jwt": "^5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "918e72f40ee32086621cfa7affdbbcbe",
+    "content-hash": "f09c8a42c92dbf10d6b0fb4c86d1436a",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -62,6 +62,60 @@
                 }
             ],
             "time": "2021-02-02T04:29:14+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v5.2.1"
+            },
+            "time": "2021-02-12T00:02:00+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/api/register.php
+++ b/api/register.php
@@ -20,8 +20,11 @@ try {
         $register_data->password
     );
 
-    echo Response::ok()
-        ->toJSON(User::register($userInfo));
+    $payload = array(
+        'token' => User::register($userInfo)
+    );
+
+    echo Response::ok()->toJSON($payload);
 } catch (InvalidArgumentException $e) {
     echo Response::error()->toJSON((object) array(
         'message' => $e->getMessage(),

--- a/api/src/Endpoints/User.php
+++ b/api/src/Endpoints/User.php
@@ -1,20 +1,36 @@
 <?php namespace App\Endpoints;
 
+use Firebase\JWT\JWT;
+
 use App\Lib\Logger;
+use App\Lib\Config;
+use App\Types\Password;
+use App\Types\EmailAddress;
 use App\Endpoints\User\RegisterUserInfo;
 
-/**
- * @codeCoverageIgnore
- */
 final class User {
     private function __construct() {}
 
-    public static function register(RegisterUserInfo $userInfo): bool {
+    private static function makeJwt(EmailAddress $email, Password $password): string {
+        $payload = array();
+        // usually you'd query the db and check if set or whatever
+        // but this is how you'd send a jwt back
+        if (isset($email) && isset($password)) {
+            $payload['uid'] = 0;
+        } else {
+            $payload['error'] = 'This is not fully implemented! But you have to AT LEAST give a user/password';
+        }
+
+        $key = Config::get('KEY');
+        return JWT::encode($payload, $key);
+    }
+
+    public static function register(RegisterUserInfo $userInfo): string {
 
         // Insert into database
         $logger = new Logger();
         $logger->info("registering your user: " . print_r($userInfo, true));
 
-        return true;
+        return Self::makeJwt($userInfo->email, $userInfo->password);
     }
 }

--- a/api/tests/UserTest.php
+++ b/api/tests/UserTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+use Firebase\JWT\JWT;
+
+use PHPUnit\Framework\TestCase;
+
+use App\Lib\Config;
+use App\Endpoints\User;
+use App\Endpoints\User\RegisterUserInfo;
+
+final class UserTest extends TestCase {
+    public function testRegisterCreatesJwtWithGoodData(): void {
+        $registerInfo = RegisterUserInfo::create("test", "hi@example.com", "Abc12345");
+        $jwt = User::register($registerInfo);
+
+        $this->assertTrue(
+            array_key_exists(
+                'uid',
+                JWT::decode($jwt, 
+                    Config::get('KEY'), 
+                    array('HS256')
+                )
+            ),
+        );
+    }
+}

--- a/api/tests/testdata/config.php
+++ b/api/tests/testdata/config.php
@@ -2,4 +2,5 @@
 return [
     'BEST_FOOD' => "AVOCADO",
     'COOLEST_DOG' => "SNOOPY",
+    'KEY' => '5f2b5cdbe5194f10b3241568fe4e2b24',
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^4.6.0",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
+    "ts-dot-prop": "^1.4.3",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -3,6 +3,7 @@ dependencies:
   bootstrap: 4.6.0
   bootstrap-vue: 2.21.2_vue@2.6.12
   core-js: 3.9.1
+  ts-dot-prop: 1.4.3
   vue: 2.6.12
   vue-router: 3.5.1
   vuex: 3.6.2_vue@2.6.12
@@ -2549,7 +2550,7 @@ packages:
       integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
   /axios/0.21.1:
     dependencies:
-      follow-redirects: 1.13.3_debug@4.3.1
+      follow-redirects: 1.13.3
     dev: false
     resolution:
       integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
@@ -5185,9 +5186,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
-  /follow-redirects/1.13.3_debug@4.3.1:
-    dependencies:
-      debug: 4.3.1
+  /follow-redirects/1.13.3:
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -5857,7 +5856,7 @@ packages:
   /http-proxy/1.18.1_debug@4.3.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.13.3_debug@4.3.1
+      follow-redirects: 1.13.3
       requires-port: 1.0.0
     dev: true
     engines:
@@ -10560,6 +10559,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+  /ts-dot-prop/1.4.3:
+    dependencies:
+      ts-util-is: 1.2.1
+    dev: false
+    resolution:
+      integrity: sha512-1msDawk2hmHBetEGw1uQiZS1o5dKfZNiT/8j/qZYVNZFs7HwPlz57elvFc3BNFg7DKCoVb/o5IGXsC+ptr6D5w==
   /ts-jest/24.3.0_jest@24.9.0:
     dependencies:
       bs-logger: 0.2.6
@@ -10609,6 +10614,10 @@ packages:
         optional: true
     resolution:
       integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+  /ts-util-is/1.2.1:
+    dev: false
+    resolution:
+      integrity: sha512-OLukOZykUt2BsN3Qu1ptEiXbz6afpUSryVkMhupk3gv23cwyYWHhg0MONhkBnVCjJ4E8y4xG+cBWxMoYuXdQLA==
   /tsconfig/7.0.0:
     dependencies:
       '@types/strip-bom': 3.0.0
@@ -11600,6 +11609,7 @@ specifiers:
   prettier: ^2.2.1
   sass: ^1.26.5
   sass-loader: ^8.0.2
+  ts-dot-prop: ^1.4.3
   typescript: ~4.1.5
   vue: ^2.6.11
   vue-router: ^3.2.0


### PR DESCRIPTION
JWT (json web token)s are lightweight authentication tokens.
This uses the firebase implementation of JWTs to send back an
authentication token from register. 

- Add firebase/php-jwt as a dep
- Return a jwt from user registration
- Set token in frontend Vuex Store

Set this token on the payload of any request which needs to be made by an authenticated user (any write other than login/registration) and then use `JWT::decode($token, $key, array('HS256' /* in our case */))` and read the userId from that object to check that the user has been issued a JWT.

### security note
 encryption key for creating the jet is currently hardcoded into the source. This is a terrible practice, and should never be done. This should really be updated to read from an environment variable, but key management is hard and this is a school project application. I think we're ok to not have to deal with the problems of key management.
