### PR TITLE
Enable test runner in php container

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,2 +1,6 @@
 FROM php:7.4-fpm
 RUN docker-php-ext-install mysqli
+RUN yes | pecl install xdebug \
+    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,9 @@
 {
     "scripts": {
         "test": "vendor/bin/phpunit tests --color",
-        "test:watch": "watch 'npm run --silent test'"
+        "test:watch": "watch 'npm run --silent test'",
+        "test:docker": "docker-compose -f ../docker-compose.yml exec php vendor/bin/phpunit tests --color",
+        "test:docker:watch": "watch 'npm run --silent test:docker'"
     },
 	"devDependencies": {
 		"watch": "^1.0.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   php:
     build: ./api
     volumes:
-      - ./api:/cs450-backend
+      - ./api:/var/www/html
     env_file:
       - dev.env
     links:


### PR DESCRIPTION
**requires rebuild of php container**
`docker-compose up --build` 

Adds xdebug php extension to php container
Tests can be run using `docker-compose exec php vendor/bin/phpunit tests
--color`

*or*

from inside the `api/` dir
`npm run test:docker` // `npm run test:docker:watch`
