### PR TITLE
Finish registration flow

### DIFF
--- a/api/api/index.php
+++ b/api/api/index.php
@@ -36,6 +36,7 @@ switch ($route[0]) {
         } catch (Exception $e) {
             echo Response::error()->toJSON(array(
                 'message' => strval($e),
+                'code' => $e->getCode(),
             ));
         }
 

--- a/api/src/CS450/Lib/Exception.php
+++ b/api/src/CS450/Lib/Exception.php
@@ -5,6 +5,7 @@ namespace CS450\Lib;
 class Exception extends \Exception {
     public function __construct(\Throwable $previous) {
         parent::__construct("Something went wrong on our end.", $previous->getCode(), $previous);
+
     }
 
     public function __toString(): string {

--- a/api/src/CS450/Model/User.php
+++ b/api/src/CS450/Model/User.php
@@ -68,7 +68,7 @@ final class User {
         $this->logger->debug(sprintf("verifying stored hash %s against new hash %s for user %d", $storedPassword, $password, $uid));
 
         if (!$password->verifyhash($storedPassword)) {
-            throw new \Exception("Incorrect password");
+            throw new \Exception("Incorrect password", 69);
         }
 
         $this->logger->info(sprintf(
@@ -80,7 +80,7 @@ final class User {
     }
 
     public function register(RegisterUserInfo $userInfo): string {
-        $insertUserSql = "INSERT INTO tbl_fact_users (name, email, password, department) VALUES (?, ?, ?, ?)";
+        $insertUserSql = "INSERT INTO tbl_fact_users (name, email, password, department, user_role) VALUES (?, ?, ?, ?, 'FACULTY')";
 
         $conn = $this->db->getConnection();
         $stmt = $conn->prepare($insertUserSql);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "bootstrap": "^4.6.0",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
-    "ts-dot-prop": "^1.4.3",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,15 +1,34 @@
 <template>
   <div id="app">
     <b-nav id="nav">
-      <router-link to="/">Register</router-link>
-      <span class="pl-1 pr-1">|</span>
+      <span v-if="!authenticated">
+        <router-link to="/">Register</router-link>
+        <span class="pl-1 pr-1">|</span>
+      </span>
       <router-link to="/about">About</router-link>
     </b-nav>
     <b-container>
+      <b-alert fade :show="errorMsg !== '' " variant="danger" dismissible @dismissed="clearError">{{
+      errorMsg
+    }}</b-alert>
       <router-view />
     </b-container>
   </div>
 </template>
+
+<script>
+import { mapGetters, mapMutations } from "vuex";
+
+export default {
+  name: "App",
+  computed: {
+    ...mapGetters(["errorMsg", "authenticated"])
+  },
+  methods: {
+    ...mapMutations(["clearError"])
+  }
+}
+</script>
 
 <style lang="scss">
 #app {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,8 @@
 import Vue from "vue";
 import VueRouter, { RouteConfig } from "vue-router";
-import Register from "../views/Register.vue";
+
+import Register from "@/views/Register.vue";
+import Login from "@/views/Login.vue";
 
 Vue.use(VueRouter);
 
@@ -9,6 +11,12 @@ const routes: Array<RouteConfig> = [
     path: "/",
     name: "Register",
     component: Register,
+  },
+  {
+    path: "/login/:prefillEmail*",
+    name: "Login",
+    component: Login,
+    props: true
   },
   {
     path: "/about",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -6,10 +6,25 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     token: "",
+    errorMsg: ""
+  },
+  getters: {
+    errorMsg: (state) => {
+      return state.errorMsg;
+    },
+    authenticated: (state) => {
+      return state.token && state.token !== ""
+    }
   },
   mutations: {
     setToken(state, token) {
       state.token = token;
     },
+    setError(state, message) {
+      state.errorMsg = message;
+    },
+    clearError(state) {
+      state.errorMsg = "";
+    }
   },
 });

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,40 @@
+<template>
+    <div>
+        <b-form-group
+        label="Email address:"
+        label-for="email"
+        description="We'll never share your email with anyone else."
+      >
+        <b-form-input
+          id="email"
+          v-model="form.email"
+          type="email"
+          placeholder="Enter email"
+          required
+        ></b-form-input>
+      </b-form-group>
+
+      <b-form-group label="Password:" label-for="password">
+        <b-form-input
+            id="password"
+            v-model="form.password"
+            placeholder="Password"
+            type="password"
+            required />
+      </b-form-group>
+      </div>
+</template>
+
+<script>
+export default {
+    name: "Login",
+    data() {
+        return {
+            form: {
+                email: this.$route?.params?.prefillEmail ?? "",
+                password: "",
+            },
+        }
+    }
+}
+</script>

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -1,8 +1,5 @@
 <template>
   <div :class="{ shake: registrationRejected }">
-    <b-alert fade :show="registrationRejected" variant="danger">{{
-      registrationRejectedMsg
-    }}</b-alert>
     <b-form @submit="onSubmit">
       <b-form-group label="Your Name:" label-for="name">
         <b-form-input
@@ -77,7 +74,6 @@
 <script lang="ts">
 import Vue from "vue";
 import axios from "axios";
-import * as dot from "ts-dot-prop";
 import store from "@/store";
 import Borat from "@/components/BoratValidated.vue";
 
@@ -129,6 +125,7 @@ export default Vue.extend({
   methods: {
     onSubmit(event: Event): void {
       event.preventDefault();
+      
       if (!(this.passwordsMatch && this.pwRequirements)) {
         return;
       }
@@ -140,13 +137,19 @@ export default Vue.extend({
         .then(({ data }) => {
           const { token } = data;
           store.commit("setToken", token);
+          this.$router.replace("/about");
         })
         .catch((error) => {
-          this.registrationRejectedMsg = dot.get(
-            error,
-            "response.data.message",
-            "Something unexpected happened 😵"
-          );
+          this.form.password = "";
+          this.verify.password = "";
+
+          const {message: errMsg, code: errCode} = error.response?.data;
+          this.$store.commit("setError", errMsg 
+            ?? "Something unexpected happened 😵");
+          
+          if (errCode === 69) {
+            this.$router.replace(`/login/${this.form.email}`);
+          }
         });
     },
     async loadDepartments() {


### PR DESCRIPTION
* Redirect to login view if user exists but password wrong
  * Prefill email if user rejected for password
* Change error message to be global based on store
* Return error codes from backend with messages

# Registration

As a new user of the system
I would like to register
so that I can use the system

**Acceptance Criteria**
- [x] basic reg
*GIVEN* an unregistered email/name/password
*WHEN* I click register
*THEN* I am registered in the database

- [x] registration as login
*GIVEN* an unregistered email/name/password
*WHEN* I click register
*THEN* I am redirected to home as an authenticated user

- [x] redirect to login
*GIVEN* an already registered email with an incorrect(different) password
*WHEN* I click register
*THEN* I am redirected to login

- [x] registration as login 2
*GIVEN* an already registered email with a correct password (same as in db)
*WHEN* I click register
*THEN* I am logged in


