### PR TITLE
Call login endpoint from frontend and store token

### DIFF
--- a/frontend/src/api/definitions.ts
+++ b/frontend/src/api/definitions.ts
@@ -1,0 +1,3 @@
+export interface AuthResponse {
+    token: string;
+}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import Vuex, { mapActions } from "vuex";
+import Vuex from "vuex";
 import axios from "axios";
 
 import { AuthResponse } from "@/api/definitions";
@@ -23,14 +23,13 @@ export default new Vuex.Store({
       return state.departments;
     },
     departmentOptions: (state) => {
-      return state.departments
-      .map((dept: { id: number; name: string }) => {
+      return state.departments.map((dept: { id: number; name: string }) => {
         return {
           value: dept.id,
           text: dept.name,
         };
       });
-    }
+    },
   },
   mutations: {
     setDepartments(state, departments = []) {
@@ -38,10 +37,10 @@ export default new Vuex.Store({
     },
     setAuthData(state, authData) {
       state.token = authData;
-      localStorage.setItem('authData', JSON.stringify(authData));
-      axios.defaults.headers.common['Authorization'] = `Bearer ${
-        authData.token
-      }`;
+      localStorage.setItem("authData", JSON.stringify(authData));
+      axios.defaults.headers.common[
+        "Authorization"
+      ] = `Bearer ${authData.token}`;
     },
     setError(state, message) {
       state.errorMsg = message;
@@ -51,19 +50,19 @@ export default new Vuex.Store({
     },
   },
   actions: {
-    authAction({ commit }, { actionName, credentials} ) {
-      commit('clearError');
+    authAction({ commit }, { actionName, credentials }) {
+      commit("clearError");
 
       return axios
         .post<AuthResponse>(`/api/auth/${actionName}`, credentials)
         .then(({ data }) => {
           const { token } = data;
-          commit('setAuthData', token);
+          commit("setAuthData", token);
         })
         .catch((error) => {
           const { message: errMsg, code: errCode } = error.response?.data;
 
-          commit('setError', errMsg ?? "Something unexpected happened 😵");
+          commit("setError", errMsg ?? "Something unexpected happened 😵");
           throw errCode;
         });
     },
@@ -81,7 +80,7 @@ export default new Vuex.Store({
     },
     async fetchDepartments({ commit }) {
       const { data } = await axios.get("/api/departments");
-      commit('setDepartments', data);
-    }
-  }
+      commit("setDepartments", data);
+    },
+  },
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,5 +1,8 @@
 import Vue from "vue";
-import Vuex from "vuex";
+import Vuex, { mapActions } from "vuex";
+import axios from "axios";
+
+import { AuthResponse } from "@/api/definitions";
 
 Vue.use(Vuex);
 
@@ -7,6 +10,7 @@ export default new Vuex.Store({
   state: {
     token: "",
     errorMsg: "",
+    departments: [],
   },
   getters: {
     errorMsg: (state) => {
@@ -15,10 +19,29 @@ export default new Vuex.Store({
     authenticated: (state) => {
       return state.token && state.token !== "";
     },
+    departments: (state) => {
+      return state.departments;
+    },
+    departmentOptions: (state) => {
+      return state.departments
+      .map((dept: { id: number; name: string }) => {
+        return {
+          value: dept.id,
+          text: dept.name,
+        };
+      });
+    }
   },
   mutations: {
-    setToken(state, token) {
-      state.token = token;
+    setDepartments(state, departments = []) {
+      state.departments = departments;
+    },
+    setAuthData(state, authData) {
+      state.token = authData;
+      localStorage.setItem('authData', JSON.stringify(authData));
+      axios.defaults.headers.common['Authorization'] = `Bearer ${
+        authData.token
+      }`;
     },
     setError(state, message) {
       state.errorMsg = message;
@@ -27,4 +50,38 @@ export default new Vuex.Store({
       state.errorMsg = "";
     },
   },
+  actions: {
+    authAction({ commit }, { actionName, credentials} ) {
+      commit('clearError');
+
+      return axios
+        .post<AuthResponse>(`/api/auth/${actionName}`, credentials)
+        .then(({ data }) => {
+          const { token } = data;
+          commit('setAuthData', token);
+        })
+        .catch((error) => {
+          const { message: errMsg, code: errCode } = error.response?.data;
+
+          commit('setError', errMsg ?? "Something unexpected happened 😵");
+          throw errCode;
+        });
+    },
+    login({ dispatch }, credentials) {
+      return dispatch("authAction", {
+        actionName: "login",
+        credentials,
+      });
+    },
+    register({ dispatch }, credentials) {
+      return dispatch("authAction", {
+        actionName: "register",
+        credentials,
+      });
+    },
+    async fetchDepartments({ commit }) {
+      const { data } = await axios.get("/api/departments");
+      commit('setDepartments', data);
+    }
+  }
 });

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <b-form @submit.prevent="onSubmit">
     <b-form-group
       label="Email address:"
       label-for="email"
@@ -23,11 +23,16 @@
         required
       />
     </b-form-group>
-  </div>
+
+    <div>
+      <b-button type="submit" variant="primary">Submit</b-button>
+    </div>
+  </b-form>
 </template>
 
-<script>
+<script lang="ts">
 import Vue from "vue";
+import { mapActions } from "vuex";
 
 export default Vue.extend({
   name: "Login",
@@ -39,5 +44,17 @@ export default Vue.extend({
       },
     };
   },
+  methods: {
+    ...mapActions(["login"]),
+    onSubmit(): void {
+      this.login(this.form)
+      .then(() => {
+        //this.$router.replace("/about");
+      })
+      .catch((errCode: number) => {
+        this.form.password = "";
+      });
+    }
+  }
 });
 </script>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -48,13 +48,13 @@ export default Vue.extend({
     ...mapActions(["login"]),
     onSubmit(): void {
       this.login(this.form)
-      .then(() => {
-        //this.$router.replace("/about");
-      })
-      .catch((errCode: number) => {
-        this.form.password = "";
-      });
-    }
-  }
+        .then(() => {
+          //this.$router.replace("/about");
+        })
+        .catch(() => {
+          this.form.password = "";
+        });
+    },
+  },
 });
 </script>

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -122,7 +122,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapMutations(["setToken", "setError"]),
-    ...mapActions(['register', 'fetchDepartments']),
+    ...mapActions(["register", "fetchDepartments"]),
     onSubmit(): void {
       if (!(this.passwordsMatch && this.pwRequirements)) {
         return;
@@ -142,7 +142,7 @@ export default Vue.extend({
       });
     },
   },
-  mounted() {
+  created() {
     this.fetchDepartments();
   },
 });

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -73,12 +73,9 @@
 
 <script lang="ts">
 import Vue from "vue";
-import axios from "axios";
 import { mapActions, mapGetters, mapMutations } from "vuex";
 
-import store from "@/store";
 import Borat from "@/components/BoratValidated.vue";
-import { AuthResponse } from "@/api/defintions";
 
 export default Vue.extend({
   name: "Register",
@@ -129,17 +126,17 @@ export default Vue.extend({
       }
 
       this.register(this.form)
-      .then(() => {
-        //this.$router.replace("/about");
-      })
-      .catch((errCode: number ) => {
-        this.form.password = "";
-        this.verify.password = "";
+        .then(() => {
+          //this.$router.replace("/about");
+        })
+        .catch((errCode: number) => {
+          this.form.password = "";
+          this.verify.password = "";
 
-        if (errCode === 69) {
+          if (errCode === 69) {
             this.$router.replace(`/login/${this.form.email}`);
           }
-      });
+        });
     },
   },
   created() {

--- a/frontend/tests/unit/register.spec.js
+++ b/frontend/tests/unit/register.spec.js
@@ -1,11 +1,12 @@
 import BootstrapVue from "bootstrap-vue";
 import { createLocalVue, mount } from "@vue/test-utils";
 import Register from "@/views/Register.vue";
+import store from "@/store";
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 
 it("exists", () => {
-  const wrapper = mount(Register, { localVue });
+  const wrapper = mount(Register, { localVue, store });
   expect(wrapper.exists()).toBe(true);
 });


### PR DESCRIPTION
Move shared logic between registration and login
into common action. Idea is more or less identical
with the only difference being
  1) data required by api
  2) follow on actions

Shared axios/error logic has been abstracted away
into common code
