### PR TITLE
send user info after auth

### DIFF
--- a/api/app/config.php
+++ b/api/app/config.php
@@ -5,10 +5,13 @@ use Appconfig\load_db_config;
 
 use Psr\Container\ContainerInterface;
 use function DI\factory;
+use function DI\create;
 
 use Monolog\Logger;
 use Monolog\ErrorHandler;
 use Monolog\Handler\StreamHandler;
+
+use CS450\Model\UserBuilder;
 
 use CS450\Service\DbService;
 use CS450\Service\JwtService;
@@ -36,6 +39,8 @@ return [
     "env" => empty(getenv("PIPELINE_STAGE")) ? "development" : getenv("PIPELINE_STAGE"),
     "db" => $db_config,
     "jwt" => $jwt_config,
+    UserBuilder::class => create()
+        ->constructor(DI\get(DbService::class)),
     DbService::class => DI\Autowire(CS450\Service\Db\MysqlDb::class),
     JwtService::class => DI\Autowire(CS450\Service\Jwt\FirebaseJwt::class),
     EmailService::class => DI\Autowire(CS450\Service\Email\MailgunEmail::class),

--- a/api/src/CS450/Model/User.php
+++ b/api/src/CS450/Model/User.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace CS450\Model;
+
+use CS450\Lib\Password;
+use CS450\Lib\EmailAddress;
+
+
+final class UserBuilder {
+    public $id;
+    public $name;
+    public $email;
+    public $role;
+    public $password;
+    public $department;
+
+    function __construct() {}
+
+    function build() {
+        return new User($this);
+    }
+
+    function id($id) {
+        $this->id = $id;
+        return $this;
+    }
+
+    function name($name) {
+        $this->name = $name;
+        return $this;
+    }
+
+    function email($email) {
+        $this->email = $email;
+        return $this;
+    }
+
+    function role($role) {
+        $this->role = $role;
+        return $this;
+    }
+
+    function password($password) {
+        $this->password = $password;
+        return $this;
+    }
+
+    function department($department) {
+        $this->department = $department;
+        return $this;
+    }
+}
+
+final class User {
+    private $uid;
+    private $name;
+    private $email;
+    private $passwordHash;
+    private $role;
+    private $department;
+
+    public static function builder(): UserBuilder {
+        return new UserBuilder();
+    }
+
+    public function __construct(UserBuilder $builder) {
+        $this->uid = $builder->id;
+        $this->email = EmailAddress::fromString($builder->email);
+        $this->passwordHash = $builder->password;
+        $this->name = $builder->name;
+        $this->role = $builder->role;
+        $this->department = $builder->department;
+    }
+
+    public function getUid(): int {
+        return $this->uid;
+    }
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    public function getEmail(): EmailAddress {
+        return $this->email;
+    }
+
+    public function getPasswordHash(): string {
+        return $this->passwordHash;
+    }
+
+    public function getRole() {
+        return $this->role;
+    }
+
+    public function getDepartment() {
+        return $this->department;
+    }
+}

--- a/api/src/CS450/Model/User/LoginUserInfo.php
+++ b/api/src/CS450/Model/User/LoginUserInfo.php
@@ -11,6 +11,7 @@ use CS450\Lib\EmailAddress;
 final class LoginUserInfo {
     public $email;
     public $password;
+
     public static function create(string $email, string $password): ?self {
         $email = EmailAddress::fromString($email);
         $password = Password::fromString($password);

--- a/api/src/CS450/Model/UserBuilder.php
+++ b/api/src/CS450/Model/UserBuilder.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace CS450\Model;
+
+use CS450\Model;
+use CS450\Service\DbService;
+
+final class UserBuilder {
+    private $db;
+
+    public $id;
+    public $name;
+    public $email;
+    public $role;
+    public $password;
+    public $department;
+
+    /**
+     * Annotation combined with phpdoc:
+     *
+     * @Inject
+     * @param DbService $db
+     */
+    function __construct(DbService $db) {
+        $this->db = $db;
+    }
+
+    function build() {
+        return new User($this, $this->db);
+    }
+
+    function id($id) {
+        $this->id = $id;
+        return $this;
+    }
+
+    function name($name) {
+        $this->name = $name;
+        return $this;
+    }
+
+    function email($email) {
+        $this->email = $email;
+        return $this;
+    }
+
+    function role($role) {
+        $this->role = $role;
+        return $this;
+    }
+
+    function password($password) {
+        $this->password = $password;
+        return $this;
+    }
+
+    function department($department) {
+        $this->department = $department;
+        return $this;
+    }
+}

--- a/api/src/CS450/Model/UserFactory.php
+++ b/api/src/CS450/Model/UserFactory.php
@@ -6,20 +6,13 @@ use CS450\Lib\Password;
 use CS450\Lib\EmailAddress;
 use CS450\Model\User\RegisterUserInfo;
 
-final class User {
+final class UserFactory {
     /**
      * 
      * @Inject
      * @var \Psr\Log\LoggerInterface
      */
     private $logger;
-
-    /**
-     * 
-     * @Inject
-     * @var CS450\Service\JwtService
-     */
-    private $jwt;
 
     /**
      * 
@@ -33,7 +26,6 @@ final class User {
             'uid' => $uid,
             'role' => $role,
         );
-
         return $this->jwt->encode($payload);
     }
 

--- a/api/src/CS450/Model/UserFactory.php
+++ b/api/src/CS450/Model/UserFactory.php
@@ -18,6 +18,12 @@ final class UserFactory {
      */
     private $db;
 
+    /**
+     * @Inject
+     * @var CS450\Model\UserBuilder
+     */
+    private $userBuilder;
+
     public function findByEmail(EmailAddress $email): ?User {
         $selectEmailQ = <<<EOD
             SELECT id, name, email, password, user_role, department
@@ -46,10 +52,9 @@ final class UserFactory {
 
         $result = $stmt->get_result();
         $userRow = $result->fetch_assoc();
-        $this->logger->info($userRow);
 
         return $userRow
-            ? User::builder()
+            ? $this->userBuilder
                 ->id($userRow["id"])
                 ->name($userRow["name"])
                 ->email($userRow["email"])
@@ -60,110 +65,3 @@ final class UserFactory {
             : null;
     }
 }
-
-//     /**
-//      * @Inject
-//      * @var \Psr\Log\LoggerInterface
-//      */
-//     private $logger;
-
-//     /**
-//      * @Inject
-//      * @var CS450\Service\DbService
-//      */
-//     private $db;
-
-//     public function login(EmailAddress $email, Password $password): User {
-        // $conn = $this->db->getConnection();
-
-        // $user = $user->findByEmail($email);
-        // return null;
-        
-        // $selectEmailQ = "SELECT id, name, email, password, user_role, department FROM tbl_fact_users WHERE email=?";
-        // $stmt = $conn->prepare($selectEmailQ);
-
-        // if (!$stmt) {
-        //     $errMsg = sprintf("An error occurred preparing your query: %s, %s", $selectEmailQ, $conn->error);
-        //     throw new \Exception($errMsg);
-        // }
-
-        // $executed = $stmt->bind_param(
-        //     "s",
-        //     $email,
-        // ) && $stmt->execute();
-
-        // if (!$executed) {
-        //     throw new \Exception($conn->error);
-        // }
-
-        // $result = $stmt->get_result();
-        // $row = $result->fetch_assoc();
-//         //$stmt->fetch();
-
-//         $this->logger->debug(sprintf("verifying stored hash %s against new hash %s for user %d", $row["password"], $password, $row["id"]));
-
-//         if (!$storedPassword) {
-//             throw new \Exception("User not found", 420);
-//         }
-//         else if (!$password->verifyhash($row["password"])) {
-//             throw new \Exception("Incorrect password", 69);
-//         }
-
-//         $this->logger->info(sprintf(
-//             "User (%s) has been authenticated with role %s",
-//             $email,
-//             $row["user_role"],
-//         ));
-//     }
-
-//     public function register(RegisterUserInfo $userInfo): string {
-//         $role = 'FACULTY';
-//         $insertUserSql = "INSERT INTO tbl_fact_users (name, email, password, department, user_role) VALUES (?, ?, ?, ?, '$role')";
-
-//         $conn = $this->db->getConnection();
-//         $stmt = $conn->prepare($insertUserSql);
-
-//         if (!$stmt) {
-//             $errMsg = sprintf("An error occurred preparing your query: %s - %s", $insertUserSql, $conn->error);
-//             throw new \Exception($errMsg);
-//         }
-
-//         $executed = $stmt->bind_param(
-//             "sssd",
-//             $userInfo->name,
-//             $userInfo->email,
-//             $userInfo->password,
-//             $userInfo->department,
-//         ) && $stmt->execute() && $stmt->close();
-
-//         if (!$executed) {
-//             if (Self::errorIsEmailExists($conn->error_list[0]["errno"])) {
-//                 $this->logger->info(sprintf(
-//                     "Existing user found checking password %s %s",
-//                     $userInfo->email,
-//                     $userInfo->password,
-//                 ));
-
-//                 // check if passwords match.
-//                 // -> if so log the user in
-//                 // else -> redirect to login with error email exists
-//                 return $this->login(
-//                     $userInfo->email,
-//                     $userInfo->password,
-//                 );
-//             } else {
-//                 // Something went wrong at the DB level
-//                 throw new \Exception($conn->error);
-//             }
-//         }
-
-//         $uid = $conn->insert_id;
-//         $this->logger->info(sprintf("Created new user with id: %d", $uid));
-
-//         return $this->makeJwt($uid, $role);
-//     }
-
-//     private static function errorIsEmailExists(int $errorcode): bool {
-//         return $errorcode == 1062;
-//     }
-// }

--- a/api/tests/UserFactoryTest.php
+++ b/api/tests/UserFactoryTest.php
@@ -18,6 +18,8 @@ final class UserFactoryTest extends TestCase {
 
     protected function setUp(): void {
         $conn = self::$db->getConnection();
+        $result = $conn->query("SET FOREIGN_KEY_CHECKS = 0");
+        $result = $conn->query("TRUNCATE TABLE tbl_fact_users");
         $result = $conn->query(sprintf(
             "INSERT INTO tbl_fact_users (name, email, password, department) VALUES ('%s', '%s', '%s', %d)",
             "Test User",
@@ -31,7 +33,8 @@ final class UserFactoryTest extends TestCase {
     protected function tearDown(): void
     {
         $conn = self::$db->getConnection();
-        $result = $conn->query("DELETE FROM tbl_fact_users WHERE email='test@example.com'");
+        $result = $conn->query("SET FOREIGN_KEY_CHECKS = 0");
+        $result = $conn->query("TRUNCATE TABLE tbl_fact_users");
         $this->assertTrue($result != false);
     }
 

--- a/api/tests/UserFactoryTest.php
+++ b/api/tests/UserFactoryTest.php
@@ -2,12 +2,12 @@
 
 use PHPUnit\Framework\TestCase;
 
-use CS450\Model\User;
+use CS450\Model\UserFactory;
 use CS450\Lib\Password;
 use CS450\Model\User\LoginUserInfo;
 use CS450\Model\User\RegisterUserInfo;
 
-final class UserTest extends TestCase {
+final class UserFactoryTest extends TestCase {
 
     private static $container;
     private static $db;

--- a/api/tests/UserTest.php
+++ b/api/tests/UserTest.php
@@ -3,25 +3,55 @@
 use PHPUnit\Framework\TestCase;
 
 use CS450\Model\User;
+use CS450\Lib\Password;
 use CS450\Lib\EmailAddress;
 
 final class UserTest extends TestCase {
+    private static $db;
+    private static $container;
+
+    public static function setUpBeforeClass(): void {
+        self::$container = require __DIR__ . '/testdata/bootstrap.php';
+        self::$db = self::$container->get(CS450\Service\DbService::class);
+    }
+
+    protected function setUp(): void {
+        $conn = self::$db->getConnection();
+        $result = $conn->query("SET FOREIGN_KEY_CHECKS = 0");
+        $result = $conn->query("TRUNCATE TABLE tbl_fact_users");
+        $result = $conn->query(sprintf(
+            "INSERT INTO tbl_fact_users (name, email, password, department) VALUES ('%s', '%s', '%s', %d)",
+            "Test User",
+            "test@example.com",
+            Password::fromString("TestPassword1"),
+            1
+        ));
+        $this->assertTrue($conn->error === "", $conn->error);
+    }
+
+    protected function tearDown(): void
+    {
+        $conn = self::$db->getConnection();
+        $result = $conn->query("SET FOREIGN_KEY_CHECKS = 0");
+        $result = $conn->query("TRUNCATE TABLE tbl_fact_users");
+        $this->assertTrue($result != false);
+    }
 
     public function testCreatesFromBuilder(): void {
         $pwHash = password_hash("test.PASSword.secure", PASSWORD_DEFAULT);
-        $user = User::builder()
+        $user = self::$container->get(CS450\Model\UserBuilder::class)
             ->id(1)
             ->name("Test")
-            ->email("test@example.net")
-            ->role("TEST")
+            ->email("test@example.com")
+            ->role("FACULTY")
             ->password($pwHash)
             ->department(1)
             ->build();
 
-        $this->assertEquals(1, $user->getUid());
+        $this->assertEquals(1, $user->getId());
         $this->assertEquals("Test", $user->getName());
         $this->assertEquals(
-            EmailAddress::fromString("test@example.net"),
+            EmailAddress::fromString("test@example.com"),
             $user->getEmail()
         );
         $this->assertEquals(
@@ -29,5 +59,25 @@ final class UserTest extends TestCase {
             $user->getPasswordHash()
         );
         $this->assertEquals(1, $user->getDepartment());
+    }
+
+    public function testWritesOnSave(): void {
+        $pwHash = password_hash("test.PASSword.secure", PASSWORD_DEFAULT);
+        $user = self::$container->get(CS450\Model\UserBuilder::class)
+            ->name("Test")
+            ->email("testWritesOnSave@example.net")
+            ->role("FACULTY")
+            ->password($pwHash)
+            ->department(1)
+            ->build()
+            ->save();
+
+        $result = self::$db->getConnection()->query("SELECT * FROM tbl_fact_users WHERE email='testWritesOnSave@example.net'");
+        $data = $result->fetch_assoc();
+
+        $this->assertEquals($user->getName(), $data["name"]);
+        $this->assertEquals($user->getEmail(), EmailAddress::fromString($data["email"]));
+        $this->assertEquals($user->getRole(), $data["user_role"]);
+        $this->assertEquals($user->getDepartment(), $data["department"]);
     }
 }

--- a/api/tests/UserTest.php
+++ b/api/tests/UserTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+use CS450\Model\User;
+use CS450\Lib\EmailAddress;
+
+final class UserTest extends TestCase {
+
+    public function testCreatesFromBuilder(): void {
+        $pwHash = password_hash("test.PASSword.secure", PASSWORD_DEFAULT);
+        $user = User::builder()
+            ->id(1)
+            ->name("Test")
+            ->email("test@example.net")
+            ->role("TEST")
+            ->password($pwHash)
+            ->department(1)
+            ->build();
+
+        $this->assertEquals(1, $user->getUid());
+        $this->assertEquals("Test", $user->getName());
+        $this->assertEquals(
+            EmailAddress::fromString("test@example.net"),
+            $user->getEmail()
+        );
+        $this->assertEquals(
+            $pwHash,
+            $user->getPasswordHash()
+        );
+        $this->assertEquals(1, $user->getDepartment());
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@types/node": "^14.14.41",
         "@vue/cli-plugin-babel": "~4.5.0",
         "@vue/cli-plugin-eslint": "~4.5.0",
         "@vue/cli-plugin-router": "~4.5.0",
@@ -19,6 +20,7 @@
         "bootstrap-vue": "^2.21.2",
         "core-js": "^3.6.5",
         "vue": "^2.6.11",
+        "vue-currency-filter": "^5.2.0",
         "vue-router": "^3.2.0",
         "vuex": "^3.4.0"
       },
@@ -16355,6 +16357,11 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
       "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
+    "node_modules/vue-currency-filter": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vue-currency-filter/-/vue-currency-filter-5.2.0.tgz",
+      "integrity": "sha512-31XXEtXLDf3A7mdIAoyEkZTwpti22omp4MjoVKv0ksIC8Gk9RqW5xzeqvubeIlrxACvCPjKNTwqTmUrxFplDHw=="
+    },
     "node_modules/vue-eslint-parser": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.6.0.tgz",
@@ -30983,6 +30990,11 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
       "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
+    },
+    "vue-currency-filter": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vue-currency-filter/-/vue-currency-filter-5.2.0.tgz",
+      "integrity": "sha512-31XXEtXLDf3A7mdIAoyEkZTwpti22omp4MjoVKv0ksIC8Gk9RqW5xzeqvubeIlrxACvCPjKNTwqTmUrxFplDHw=="
     },
     "vue-eslint-parser": {
       "version": "7.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
+    "vue-currency-filter": "^5.2.0",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0"
   },

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -10,15 +10,13 @@
         <router-link to="/invite">Faculty member</router-link>
       </b-dropdown-item>
     </b-nav-item-dropdown>
-    <b-nav-item v-else>
-      <router-link to="/login">Login</router-link>
-    </b-nav-item>
 
     <b-nav-item>
       <router-link to="/about">About</router-link>
     </b-nav-item>
-    <b-nav-item v-if="authenticated" class="ml-auto" @click="logout">
-      <router-link to="">Logout</router-link>
+    <b-nav-item class="ml-auto" @click="logout">
+      <router-link v-if="authenticated" to="">Logout</router-link>
+      <router-link v-else to="/login">Login</router-link>
     </b-nav-item>
   </b-nav>
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import axios from "axios";
 import BootstrapVue from "bootstrap-vue";
+import VueCurrencyFilter from "vue-currency-filter";
 
 import App from "./App.vue";
 import router from "./router";
@@ -9,6 +10,15 @@ import store from "./store";
 import "./assets/scss/cs450.scss";
 
 Vue.use(BootstrapVue);
+Vue.use(VueCurrencyFilter, {
+  symbol: "$",
+  thousandsSeparator: ",",
+  fractionCount: 2,
+  fractionSeparator: ".",
+  symbolPosition: "front",
+  symbolSpacing: false,
+  avoidEmptyDecimals: undefined,
+});
 
 Vue.config.productionTip = false;
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,9 +1,9 @@
 import Vue from "vue";
 import VueRouter, { RouteConfig } from "vue-router";
 
-import Register from "@/views/Register.vue";
 import Login from "@/views/Login.vue";
 import Invite from "@/views/Invite.vue";
+import Register from "@/views/Register.vue";
 
 Vue.use(VueRouter);
 
@@ -18,12 +18,23 @@ const routes: Array<RouteConfig> = [
           route.params.prefillData,
           "base64"
         ).toString("utf-8");
-        return { prefillData: JSON.parse(jsonStr) };
+
+        const prefillData = JSON.parse(jsonStr);
+        return prefillData?.userDataToken
+          ? { prefillData }
+          : { prefillData: {} };
       } catch (e) {
         console.error(
           `failed to parse base64 ${route.params?.prefillData} ${e}`
         );
       }
+    },
+    beforeEnter(to, from, next) {
+      const loggedIn = localStorage.getItem("authData");
+      if (loggedIn) {
+        return next("/dashboard");
+      }
+      next();
     },
   },
   {
@@ -59,7 +70,7 @@ router.beforeEach((to, from, next) => {
   const loggedIn = localStorage.getItem("authData");
 
   if (to.matched.some((record) => record.meta?.requiresAuth) && !loggedIn) {
-    next("/");
+    return next("/");
   }
 
   next();

--- a/frontend/src/views/Invite.vue
+++ b/frontend/src/views/Invite.vue
@@ -14,7 +14,7 @@
       </b-form-group>
 
       <b-form-group
-        label="New Faculty's Email address:"
+        label="New Faculty's Email Address:"
         label-for="email"
         description="They'll receive an invitation to register at this address"
       >
@@ -27,13 +27,24 @@
         ></b-form-input>
       </b-form-group>
 
-      <b-form-group label="Enter faculty's department:" label-for="department">
-        <b-form-select id="department" v-model="form.department" :options="departmentOptions" />
+      <b-form-group label="New Faculty's Department:" label-for="department">
+        <b-form-select
+          id="department"
+          v-model="form.department"
+          :options="departmentOptions"
+        />
       </b-form-group>
 
-      <b-form-group label="Startup fund amount:" label-for="startup-fund">
-        <b-form-input id="range-1" v-model="form.startupAmount" type="range" min="50000" max="80000" step="0.1"></b-form-input>
-        <div class="mt-2">Value: {{ form.startupAmount }} thousand</div>
+      <b-form-group label="Startup Fund Amount:" label-for="startup-fund">
+        <b-form-input
+          id="range-1"
+          v-model="form.startupAmount"
+          type="range"
+          min="50000"
+          max="80000"
+          step="0.1"
+        />
+        <div class="mt-2">Value: {{ form.startupAmount | currency }}</div>
       </b-form-group>
 
       <div class="ml-auto">
@@ -55,7 +66,7 @@ export default Vue.extend({
         name: "",
         email: "",
         department: "",
-        startupAmount: 50.0,
+        startupAmount: 50000.0,
       },
       emailSent: false,
     };

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -81,6 +81,7 @@ type PrefillData = {
   name: string;
   email: string;
   department: number;
+  startupToken: string;
 };
 
 export default Vue.extend({
@@ -100,6 +101,7 @@ export default Vue.extend({
         name: this.prefillData?.name ?? "",
         password: "",
         department: this.prefillData?.department ?? 1,
+        startupToken: this.prefillData?.startupToken,
       },
       verify: {
         password: "",

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -21,6 +21,7 @@
           type="email"
           placeholder="Enter email"
           required
+          disabled
         ></b-form-input>
       </b-form-group>
 
@@ -81,7 +82,7 @@ type PrefillData = {
   name: string;
   email: string;
   department: number;
-  startupToken: string;
+  userDataToken: string;
 };
 
 export default Vue.extend({
@@ -101,7 +102,7 @@ export default Vue.extend({
         name: this.prefillData?.name ?? "",
         password: "",
         department: this.prefillData?.department ?? 1,
-        startupToken: this.prefillData?.startupToken,
+        userDataToken: this.prefillData?.userDataToken,
       },
       verify: {
         password: "",
@@ -150,6 +151,12 @@ export default Vue.extend({
   },
   created() {
     this.fetchDepartments();
+    if (!this.form.userDataToken) {
+      this.setError(
+        `Your invitation seems to have been damaged.
+        Verify the link you were sent, or contact your administrator`
+      );
+    }
   },
 });
 </script>


### PR DESCRIPTION
- Add an encrypted startup fund token to the registration url
- Display startup fund amount formatted as currency
- Set startup token on registration form
- Move login/logout to same place in navbar
- Set email and amount inside of a jwt so it can't be faked on registration request
- Rename User to UserFactory
- Refactor Login for better mvc structure
- Refactor user creation/search into factory and builder pattern
